### PR TITLE
Feature make shorter syntaxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
 
 before_script:
   - composer self-update

--- a/Helpers/helpers.php
+++ b/Helpers/helpers.php
@@ -16,7 +16,13 @@ if (! function_exists('piper')) {
             ->pipe($value, $callback);
     }
 
-    function ducter($value, callable|array ...$lines) {
+    /**
+     * @param $value
+     * @param callable|array ...$lines
+     * @return mixed|string
+     * @throws \Transprime\Piper\Exceptions\PiperException
+     */
+    function ducter($value, ...$lines) {
         $piper = \piper($value);
 
         return $piper->ln(...$lines);

--- a/Helpers/helpers.php
+++ b/Helpers/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Transprime\Piper\CallablePiper;
 use Transprime\Piper\Piper;
 
 if (! function_exists('piper')) {
@@ -13,5 +14,15 @@ if (! function_exists('piper')) {
     function piper($value, $callback = null) {
         return (new Piper())
             ->pipe($value, $callback);
+    }
+
+    function ducter($value, callable|array ...$lines) {
+        $piper = \piper($value);
+
+        return $piper->ln(...$lines);
+    }
+
+    function _p($value) {
+        return new CallablePiper(\piper($value));
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ piper(['name' => 'ade', 'hobby' => 'coding'])
     ->to('array_intersect', [0 => 'ADE'])(); //returns ['ADE']
 ```
 
-or this in PHP 8.1+
+Or this in PHP 8.1+
+Getting `['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D']` examples:
 
-Use line - as in the line in Pipe"line"
+Use line - as in the line in Pipe-"line"
 ```php
 piper("Hello World")
     ->ln(
@@ -59,7 +60,7 @@ Call functions like an array:
 _p("Hello World")
     [htmlentities(...)]
     [str_split(...)]
-    [[array_map(...), fn(string $part) => strtoupper($part)]]()
+    [[array_map(...), strtoupper(...)]]()
 ```
 
 How about Closure() on Closure
@@ -67,7 +68,8 @@ How about Closure() on Closure
 _p("Hello World")
     (htmlentities(...))
     (strtoupper(...))
-    (str_split(...))()
+    (str_split(...))
+    (array_map(...), strtoupper(...))()
 ```
 
 Cleaner with underscore `_`
@@ -75,15 +77,15 @@ Cleaner with underscore `_`
 _p("Hello World")
     ->_(htmlentities(...))
     ->_(str_split(...))
-    ->_(array_map(fn(string $part) => strtoupper($part), ...));
+    ->_(array_map(...), strtoupper(...)));
 ```
 
 Shortcut to `pipe()` is `p()`
 ```php
 _p("Hello World")
     ->p(htmlentities(...))
-    ->p(strtoupper(...))
-    ->p(str_split(...))()
+    ->p(str_split(...))
+    ->p(array_map(...), strtoupper(...))()
 ```
 
 PHP 7.4 `fn()` like
@@ -91,7 +93,7 @@ PHP 7.4 `fn()` like
 _p("Hello World")
     ->fn(htmlentities(...))
     ->fn(str_split(...))
-    ->fn(array_map(...), fn(string $part) => strtoupper($part))
+    ->fn(array_map(...), strtoupper())
     ->fn()
 ```
 
@@ -100,7 +102,7 @@ Proxied call to globally available functions
 _p("Hello World")
     ->htmlentities()
     ->str_split()
-    ->array_map(fn(string $part) => strtoupper($part))()
+    ->array_map(strtoupper(...))()
 ```
 
 Instead of:

--- a/README.md
+++ b/README.md
@@ -44,34 +44,27 @@ piper(['name' => 'ade', 'hobby' => 'coding'])
 
 ```php
 piper("Hello World")
-    ->to(htmlentities(...))
-    ->to(str_split(...))
-    ->to(array_map(fn(string $part) => strtoupper($part), ...))
+    ->ln(
+        htmlentities(...),
+        str_split(...),
+        [array_map(...), fn(string $part) => strtoupper($part)],
+    );
 ```
 
 ```php
-piper("Hello World")
-    ->on(
-    htmlentities(...),
-    str_split(...),
-    array_map(fn(string $part) => strtoupper($part), ...)
-);
-```
-
-```php
-piper(
+ducter(
     "Hello World",
     htmlentities(...),
     str_split(...),
-    array_map(fn(string $part) => strtoupper($part), ...)
-);
+    [array_map(...), fn(string $part) => strtoupper($part)],
+)
 ```
 
 ```php
 _p("Hello World")
     [htmlentities(...)]
     [str_split(...)]
-    [array_map(fn(string $part) => strtoupper($part), ...)];
+    [[array_map(...), fn(string $part) => strtoupper($part)]]()
 ```
 
 ```php
@@ -108,6 +101,13 @@ _p("Hello World")
     ->fn(str_split(...))
     ->fn(array_map(...), fn(string $part) => strtoupper($part))
     ->fn()
+```
+
+```php
+_p("Hello World")
+    ->htmlentities()
+    ->str_split()
+    ->array_map(fn(string $part) => strtoupper($part))()
 ```
 
 Instead of:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ _p("Hello World")
 ```php
 _p("Hello World")
     (htmlentities(...))
-    (str_split(...))
-    (array_map(fn(string $part) => strtoupper($part), ...));
+    (strtoupper(...))
+    (str_split(...))()
 ```
 
 ```php
@@ -91,15 +91,23 @@ _p("Hello World")
 ```php
 _p("Hello World")
     ->p(htmlentities(...))
-    ->p(str_split(...))
-    ->p(array_map(fn(string $part) => strtoupper($part), ...));
+    ->p(strtoupper(...))
+    ->p(str_split(...))()
 ```
 
 ```php
 _p("Hello World")
-    ->_p(htmlentities(...))
-    ->_p(str_split(...))
-    ->_p(array_map(fn(string $part) => strtoupper($part), ...));
+    ->_(htmlentities(...))
+    ->_(str_split(...))
+    ->_(array_map(...), fn(string $part) => strtoupper($part))()
+```
+
+```php
+_p("Hello World")
+    ->fn(htmlentities(...))
+    ->fn(str_split(...))
+    ->fn(array_map(...), fn(string $part) => strtoupper($part))
+    ->fn()
 ```
 
 Instead of:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let us take an array and do the following:
 
 - flip the array to make the keys become the values and vice versa
 - get the new keys
-- change (the keys now) values to to upper case
+- change (the keys now) values to upper case
 - take the exact item with `[0 => 'ADE']`
  
 ```php
@@ -30,6 +30,76 @@ piper(['name' => 'ade', 'hobby' => 'coding'])
     ->to('array_keys')
     ->to('array_map', fn($val) => strtoupper($val))
     ->to('array_intersect', [0 => 'ADE'])(); //returns ['ADE']
+```
+
+or this in PHP 8.1+
+
+```php
+piper(['name' => 'ade', 'hobby' => 'coding'])
+    ->to(array_flip(...))
+    ->to(array_keys(...))
+    ->to(array_map(...), fn($val) => strtoupper($val))
+    ->to(array_intersect(...), [0 => 'ADE'])(); //returns ['ADE']
+```
+
+```php
+piper("Hello World")
+    ->to(htmlentities(...))
+    ->to(str_split(...))
+    ->to(array_map(fn(string $part) => strtoupper($part), ...))
+```
+
+```php
+piper("Hello World")
+    ->on(
+    htmlentities(...),
+    str_split(...),
+    array_map(fn(string $part) => strtoupper($part), ...)
+);
+```
+
+```php
+piper(
+    "Hello World",
+    htmlentities(...),
+    str_split(...),
+    array_map(fn(string $part) => strtoupper($part), ...)
+);
+```
+
+```php
+_p("Hello World")
+    [htmlentities(...)]
+    [str_split(...)]
+    [array_map(fn(string $part) => strtoupper($part), ...)];
+```
+
+```php
+_p("Hello World")
+    (htmlentities(...))
+    (str_split(...))
+    (array_map(fn(string $part) => strtoupper($part), ...));
+```
+
+```php
+_p("Hello World")
+    ->_(htmlentities(...))
+    ->_(str_split(...))
+    ->_(array_map(fn(string $part) => strtoupper($part), ...));
+```
+
+```php
+_p("Hello World")
+    ->p(htmlentities(...))
+    ->p(str_split(...))
+    ->p(array_map(fn(string $part) => strtoupper($part), ...));
+```
+
+```php
+_p("Hello World")
+    ->_p(htmlentities(...))
+    ->_p(str_split(...))
+    ->_p(array_map(fn(string $part) => strtoupper($part), ...));
 ```
 
 Instead of:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,7 @@ piper(['name' => 'ade', 'hobby' => 'coding'])
 
 or this in PHP 8.1+
 
-```php
-piper(['name' => 'ade', 'hobby' => 'coding'])
-    ->to(array_flip(...))
-    ->to(array_keys(...))
-    ->to(array_map(...), fn($val) => strtoupper($val))
-    ->to(array_intersect(...), [0 => 'ADE'])(); //returns ['ADE']
-```
-
+Use line - as in the line in Pipe"line"
 ```php
 piper("Hello World")
     ->ln(
@@ -51,6 +44,7 @@ piper("Hello World")
     );
 ```
 
+Think about ductape on a pipe. Ducter allows such neat calls to your functions
 ```php
 ducter(
     "Hello World",
@@ -60,6 +54,7 @@ ducter(
 )
 ```
 
+Call functions like an array:
 ```php
 _p("Hello World")
     [htmlentities(...)]
@@ -67,6 +62,7 @@ _p("Hello World")
     [[array_map(...), fn(string $part) => strtoupper($part)]]()
 ```
 
+How about Closure() on Closure
 ```php
 _p("Hello World")
     (htmlentities(...))
@@ -74,6 +70,7 @@ _p("Hello World")
     (str_split(...))()
 ```
 
+Cleaner with underscore `_`
 ```php
 _p("Hello World")
     ->_(htmlentities(...))
@@ -81,6 +78,7 @@ _p("Hello World")
     ->_(array_map(fn(string $part) => strtoupper($part), ...));
 ```
 
+Shortcut to `pipe()` is `p()`
 ```php
 _p("Hello World")
     ->p(htmlentities(...))
@@ -88,13 +86,7 @@ _p("Hello World")
     ->p(str_split(...))()
 ```
 
-```php
-_p("Hello World")
-    ->_(htmlentities(...))
-    ->_(str_split(...))
-    ->_(array_map(...), fn(string $part) => strtoupper($part))()
-```
-
+PHP 7.4 `fn()` like
 ```php
 _p("Hello World")
     ->fn(htmlentities(...))
@@ -103,6 +95,7 @@ _p("Hello World")
     ->fn()
 ```
 
+Proxied call to globally available functions
 ```php
 _p("Hello World")
     ->htmlentities()
@@ -238,9 +231,6 @@ piper('array_intersect', [0 => 'ADE'])
 > Api implementation to be decided
 
 ## Additional Information
-
-Be aware that this package is part of a series of "The Proof Of Concept".
-
 See other packages in this series here:
 
 - https://github.com/omitobi/conditional [A smart PHP if...elseif...else statement]

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2"
+    "php": ">=8.1"
   },
   "require-dev": {
     "phpunit/phpunit": ">=6.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1"
+    "php": ">=7.2"
   },
   "require-dev": {
     "phpunit/phpunit": ">=6.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "php": ">=8.1"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=6.0"
+    "phpunit/phpunit": ">=6.0",
+    "symfony/var-dumper": "^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/CallablePiper.php
+++ b/src/CallablePiper.php
@@ -1,8 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Transprime\Piper;
 
-class CallablePiper
+class CallablePiper implements \ArrayAccess
 {
     private Piper $piper;
 
@@ -45,5 +45,31 @@ class CallablePiper
     public function fn(callable ...$callable)
     {
         return $this->__invoke(...$callable);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return true;
+    }
+
+    public function offsetGet(mixed ...$offset): mixed
+    {
+        if (is_array($offset[0])) {
+           return $this->__invoke(...$offset[0]);
+        }
+
+        return $this->__invoke(...$offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    public function offsetUnset(mixed $offset): void {}
+
+    /**
+     * @return mixed|self
+     */
+    public function __call(string $name, array $arguments)
+    {
+        return $this->__invoke($name, ...$arguments);
     }
 }

--- a/src/CallablePiper.php
+++ b/src/CallablePiper.php
@@ -15,7 +15,7 @@ class CallablePiper implements \ArrayAccess
      * @param callable|array|null $callable
      * @return mixed|self
      */
-    public function __invoke(callable|array ...$callable): mixed
+    public function __invoke(...$callable): mixed
     {
         return $callable ? $this->to(...$callable) : $this->up();
     }

--- a/src/CallablePiper.php
+++ b/src/CallablePiper.php
@@ -11,12 +11,16 @@ class CallablePiper
         $this->piper = $piper->to(fn($vl) => $vl);
     }
 
-    public function __invoke(callable|array $callable = null)
+    /**
+     * @param callable|array|null $callable
+     * @return mixed|self
+     */
+    public function __invoke(callable|array ...$callable): mixed
     {
-        return $callable ? $this->to($callable) : $this->up();
+        return $callable ? $this->to(...$callable) : $this->up();
     }
 
-    public function to(callable $action, ...$extraParameters): static|null|string
+    public function to(callable $action, ...$extraParameters): static
     {
         $this->piper->to($action, ...$extraParameters);
 
@@ -26,5 +30,20 @@ class CallablePiper
     public function up(callable $action = null)
     {
         return $this->piper->up($action);
+    }
+
+    public function p(callable ...$callable)
+    {
+        return $this->__invoke(...$callable);
+    }
+
+    public function _(callable ...$callable)
+    {
+        return $this->__invoke(...$callable);
+    }
+
+    public function fn(callable ...$callable)
+    {
+        return $this->__invoke(...$callable);
     }
 }

--- a/src/CallablePiper.php
+++ b/src/CallablePiper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Transprime\Piper;
+
+class CallablePiper
+{
+    private Piper $piper;
+
+    public function __construct(Piper $piper)
+    {
+        $this->piper = $piper->to(fn($vl) => $vl);
+    }
+
+    public function __invoke(callable|array $callable = null)
+    {
+        return $callable ? $this->to($callable) : $this->up();
+    }
+
+    public function to(callable $action, ...$extraParameters): static|null|string
+    {
+        $this->piper->to($action, ...$extraParameters);
+
+        return $this;
+    }
+
+    public function up(callable $action = null)
+    {
+        return $this->piper->up($action);
+    }
+}

--- a/src/On.php
+++ b/src/On.php
@@ -4,7 +4,12 @@ namespace Transprime\Piper;
 
 trait On
 {
-    public function ln(callable|array ...$functions)
+    /**
+     * @param callable|array ...$functions
+     * @return mixed|string
+     * @throws Exceptions\PiperException
+     */
+    public function ln(...$functions)
     {
         foreach ($functions as $function) {
             $callables = is_array($function) ? $function : [$function];

--- a/src/On.php
+++ b/src/On.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Transprime\Piper;
+
+trait On
+{
+    public function ln(callable|array ...$functions)
+    {
+        foreach ($functions as $function) {
+            $callables = is_array($function) ? $function : [$function];
+            $this->to(...$callables);
+        }
+
+        return $this->up();
+    }
+}

--- a/src/Piper.php
+++ b/src/Piper.php
@@ -6,6 +6,8 @@ use Transprime\Piper\Exceptions\PiperException;
 
 class Piper
 {
+    use On;
+
     private $piped = [];
 
     private $extraParameters = [];

--- a/tests/PiperTest.php
+++ b/tests/PiperTest.php
@@ -231,6 +231,11 @@ class PiperTest extends TestCase
         );
     }
 
+    private function runIfOnPHP81()
+    {
+        return (float)phpversion() >= 8.1;
+    }
+
     public function testPiperWithPHP81FirstClassCallable()
     {
         $this->assertEquals(['ADE'],
@@ -256,7 +261,7 @@ class PiperTest extends TestCase
                 ->ln(
                     htmlentities(...),
                     str_split(...),
-                    [array_map(...), fn(string $part) => strtoupper($part)],
+                    [array_map(...), strtoupper(...)],
                 )
         );
     }
@@ -268,7 +273,7 @@ class PiperTest extends TestCase
                 "Hello World",
                 htmlentities(...),
                 str_split(...),
-                [array_map(...), fn(string $part) => strtoupper($part)],
+                [array_map(...), strtoupper(...)],
             )
         );
     }
@@ -278,8 +283,8 @@ class PiperTest extends TestCase
         $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             _p("Hello World")
             (htmlentities(...))
-            (strtoupper(...))
-            (str_split(...))()
+            (str_split(...))
+            (array_map(...), strtoupper(...))()
         );
     }
 
@@ -289,7 +294,7 @@ class PiperTest extends TestCase
             _p("Hello World")
                 ->_(htmlentities(...))
                 ->_(str_split(...))
-                ->_(array_map(...), fn(string $part) => strtoupper($part))()
+                ->_(array_map(...), strtoupper(...))()
         );
     }
 
@@ -299,7 +304,7 @@ class PiperTest extends TestCase
             _p("Hello World")
                 ->p(htmlentities(...))
                 ->p(str_split(...))
-                ->p(array_map(...), fn(string $part) => strtoupper($part))()
+                ->p(array_map(...), strtoupper(...))()
         );
     }
 
@@ -309,7 +314,7 @@ class PiperTest extends TestCase
             _p("Hello World")
                 ->fn(htmlentities(...))
                 ->fn(str_split(...))
-                ->fn(array_map(...), fn(string $part) => strtoupper($part))
+                ->fn(array_map(...), strtoupper(...))
                 ->fn()
         );
     }
@@ -320,7 +325,7 @@ class PiperTest extends TestCase
             _p("Hello World")
                 [htmlentities(...)]
                 [str_split(...)]
-                [[array_map(...), fn(string $part) => strtoupper($part)]]()
+                [[array_map(...), strtoupper(...)]]()
         );
     }
 
@@ -330,7 +335,7 @@ class PiperTest extends TestCase
             _p("Hello World")
                 ->htmlentities()
                 ->str_split()
-                ->array_map(fn(string $part) => strtoupper($part))()
+                ->array_map(strtoupper(...))()
         );
     }
 }

--- a/tests/PiperTest.php
+++ b/tests/PiperTest.php
@@ -273,14 +273,44 @@ class PiperTest extends TestCase
         );
     }
 
-    public function testFunctionPiper()
+    public function testCallablePiper()
     {
         $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             _p("Hello World")
             (htmlentities(...))
-            (htmlentities(...))
             (strtoupper(...))
             (str_split(...))()
+        );
+    }
+
+    public function testUnderscoredPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+            ->_(htmlentities(...))
+            ->_(str_split(...))
+            ->_(array_map(...), fn(string $part) => strtoupper($part))()
+        );
+    }
+
+    public function testPPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+            ->p(htmlentities(...))
+            ->p(str_split(...))
+            ->p(array_map(...), fn(string $part) => strtoupper($part))()
+        );
+    }
+
+    public function testFnPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+            ->fn(htmlentities(...))
+            ->fn(str_split(...))
+            ->fn(array_map(...), fn(string $part) => strtoupper($part))
+            ->fn()
         );
     }
 }

--- a/tests/PiperTest.php
+++ b/tests/PiperTest.php
@@ -230,6 +230,36 @@ class PiperTest extends TestCase
                 ->up()
         );
     }
+
+    public function testPiperWithPHP81FirstClassCallable()
+    {
+        $this->assertEquals(['ADE'],
+            piper(['name' => 'ade', 'hobby' => 'coding'])
+                ->to(array_flip(...))
+                ->to(array_keys(...))
+                ->to(array_map(...), fn($val) => strtoupper($val))
+                ->to(array_intersect(...), [0 => 'ADE'])(),
+        );
+
+        $this->assertEquals(['H','E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            piper("Hello World")
+                ->to(htmlentities(...))
+                ->to(str_split(...))
+                ->to(array_map(...), fn(string $part) => strtoupper($part))()
+        );
+    }
+
+    public function testPiperWithLn()
+    {
+        $this->assertEquals(['H','E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+        piper("Hello World")
+            ->ln(
+                htmlentities(...),
+                str_split(...),
+                [array_map(...), fn(string $part) => strtoupper($part)],
+            )
+        );
+    }
 }
 
 class StrManipulator

--- a/tests/PiperTest.php
+++ b/tests/PiperTest.php
@@ -241,7 +241,7 @@ class PiperTest extends TestCase
                 ->to(array_intersect(...), [0 => 'ADE'])(),
         );
 
-        $this->assertEquals(['H','E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             piper("Hello World")
                 ->to(htmlentities(...))
                 ->to(str_split(...))
@@ -251,13 +251,36 @@ class PiperTest extends TestCase
 
     public function testPiperWithLn()
     {
-        $this->assertEquals(['H','E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
-        piper("Hello World")
-            ->ln(
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            piper("Hello World")
+                ->ln(
+                    htmlentities(...),
+                    str_split(...),
+                    [array_map(...), fn(string $part) => strtoupper($part)],
+                )
+        );
+    }
+
+    public function testPiperWithDucter()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            ducter(
+                "Hello World",
                 htmlentities(...),
                 str_split(...),
                 [array_map(...), fn(string $part) => strtoupper($part)],
             )
+        );
+    }
+
+    public function testFunctionPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+            (htmlentities(...))
+            (htmlentities(...))
+            (strtoupper(...))
+            (str_split(...))()
         );
     }
 }

--- a/tests/PiperTest.php
+++ b/tests/PiperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Piper\Tests;
 
@@ -287,9 +287,9 @@ class PiperTest extends TestCase
     {
         $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             _p("Hello World")
-            ->_(htmlentities(...))
-            ->_(str_split(...))
-            ->_(array_map(...), fn(string $part) => strtoupper($part))()
+                ->_(htmlentities(...))
+                ->_(str_split(...))
+                ->_(array_map(...), fn(string $part) => strtoupper($part))()
         );
     }
 
@@ -297,9 +297,9 @@ class PiperTest extends TestCase
     {
         $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             _p("Hello World")
-            ->p(htmlentities(...))
-            ->p(str_split(...))
-            ->p(array_map(...), fn(string $part) => strtoupper($part))()
+                ->p(htmlentities(...))
+                ->p(str_split(...))
+                ->p(array_map(...), fn(string $part) => strtoupper($part))()
         );
     }
 
@@ -307,10 +307,30 @@ class PiperTest extends TestCase
     {
         $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
             _p("Hello World")
-            ->fn(htmlentities(...))
-            ->fn(str_split(...))
-            ->fn(array_map(...), fn(string $part) => strtoupper($part))
-            ->fn()
+                ->fn(htmlentities(...))
+                ->fn(str_split(...))
+                ->fn(array_map(...), fn(string $part) => strtoupper($part))
+                ->fn()
+        );
+    }
+
+    public function testIndexPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+                [htmlentities(...)]
+                [str_split(...)]
+                [[array_map(...), fn(string $part) => strtoupper($part)]]()
+        );
+    }
+
+    public function testProxiedPiper()
+    {
+        $this->assertEquals(['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'],
+            _p("Hello World")
+                ->htmlentities()
+                ->str_split()
+                ->array_map(fn(string $part) => strtoupper($part))()
         );
     }
 }


### PR DESCRIPTION
PHP 8.1+ enables First-class Callable class syntax which gives cleaner call with Piper.
This PR adds the following:

Getting `['H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D']` examples:

Use line - as in the line in Pipe"line"
```php
piper("Hello World")
    ->ln(
        htmlentities(...),
        str_split(...),
        [array_map(...), strtoupper(...)],
    );
```

Think about ductape on a pipe. Ducter allows such neat calls to your functions
```php
ducter(
    "Hello World",
    htmlentities(...),
    str_split(...),
    [array_map(...), strtoupper(...)],
)
```

Call functions like an array:
```php
_p("Hello World")
    [htmlentities(...)]
    [str_split(...)]
    [[array_map(...), strtoupper(...)]]()
```

How about Closure() on Closure
```php
_p("Hello World")
    (htmlentities(...))
    (strtoupper(...))
    (str_split(...))
    (array_map(...), strtoupper(...))()
```

Cleaner with underscore `_`
```php
_p("Hello World")
    ->_(htmlentities(...))
    ->_(str_split(...))
    ->_(array_map(...), strtoupper(...));
```

Shortcut to `pipe()` is `p()`
```php
_p("Hello World")
    ->p(htmlentities(...))
    ->p(str_split(...))
    ->p(array_map(...), strtoupper(...))()
```

PHP 7.4 `fn()` like
```php
_p("Hello World")
    ->fn(htmlentities(...))
    ->fn(str_split(...))
    ->fn(array_map(...), strtoupper(...))
    ->fn()
```

Proxied call to globally available functions
```php
_p("Hello World")
    ->htmlentities()
    ->str_split()
    ->array_map(strtoupper($part))()
```